### PR TITLE
🚑 fix: fix component name casing for consistency in Page component

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -10,7 +10,7 @@ import Image from "next/image";
 import React, { useEffect, useRef } from "react";
 import { FaGithub, FaLinkedin } from "react-icons/fa";
 
-const page = () => {
+const Page = () => {
   const { lang } = useLanguageStore();
 
   const headerRef = useRef<HTMLDivElement>(null);
@@ -191,4 +191,4 @@ const page = () => {
   );
 };
 
-export default page;
+export default Page;


### PR DESCRIPTION
# Pull Request Template

## Overview
- **Purpose of this PR**: Fixed a build-blocking issue caused by incorrect component naming in page.tsx
- **Related Issue**: None

## Changes
- Renamed the default exported component in page.tsx from page to Page
- Ensured the component name starts with an uppercase letter to comply with React and ESLint rules

## Testing
- **What was tested**:
  - Successfully ran next build with ESLint enabled
  - Verified that the Page component renders correctly in both local and Docker environments
- **Known Issues**:
  - None

## Fix
- This PR resolves the ESLint error:
"React Hook "useXXX" is called in function "page" that is neither a React function component nor a custom React Hook function"
- The error occurred because React components must start with an uppercase letter (Page, not page)