### PR TITLE
🚑 fix: simplify map function in CareerTimeline component

### DIFF
--- a/frontend/src/components/Experience/CareerTimeLine.tsx
+++ b/frontend/src/components/Experience/CareerTimeLine.tsx
@@ -67,7 +67,7 @@ const CareerTimeline = () => {
         <div className="absolute top-[44px] left-0 right-0 h-1 bg-gray-800 z-0" />
 
         <div className="flex gap-12 overflow-x-auto pb-6 pl-6 pr-6">
-          {filteredData.map((item, index) => {
+          {filteredData.map((item) => {
             const originalIndex = data.findIndex(
               (dataItem) => dataItem === item
             );


### PR DESCRIPTION
# Pull Request Template

## Overview
- **Purpose of this PR**: Fixed a build-blocking ESLint error by removing an unused index variable from a map function
- **Related Issue**: None

## Changes
- Removed the unused index parameter from a map function in CareerTimeLine.tsx
- Addressed ESLint rule @typescript-eslint/no-unused-vars that caused the Next.js build to fail

## Testing
- **What was tested**:
  - Confirmed CareerTimeLine component renders correctly without index
- **Known Issues**:
  - Some warnings (e.g., related to <img> tags) remain but do not affect the build process

## Fix
- Removed the unused index variable from a map function to comply with ESLint rules and allow the build to complete successfully