### PR TITLE
🚑 fix: add environment variable configuration for public API URL in N…

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  env: {
+    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
# Pull Request Template

## Overview
- **Purpose of this PR**: Ensured that the NEXT_PUBLIC_API_URL environment variable is correctly exposed to the client-side by adding it to next.config.js
- **Related Issue**: None

## Changes
- Created or updated frontend/next.config.js to explicitly pass NEXT_PUBLIC_API_URL from .env to Next.js client environment
- This allows frontend components to access process.env.NEXT_PUBLIC_API_URL without returning undefined

## Testing
- **What was tested**:
  - Verified that the frontend correctly reads and uses NEXT_PUBLIC_API_URL at runtime
  - Confirmed successful API requests to the backend after redeploying with updated environment configuration
- **Known Issues**:
  - None

## Fix
- Resolved the issue where API requests were being sent to /undefined/contact due to missing environment variable in the client bundle
- By declaring the variable in next.config.js, Next.js includes it during build time, enabling proper usage in the frontend