### PR TITLE
🚑 fix: update frontend port mapping to expose the correct port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
   frontend:
     build: ./frontend
     ports:
-      - "80:3000"
+      - "3000:3000"
     depends_on:
       - backend
     env_file:


### PR DESCRIPTION
# Pull Request Template

## Overview
- **Purpose of this PR**: Adjust Docker port binding to resolve port conflict with Nginx
- **Related Issue**: None

## Changes
- Updated docker-compose.yml:
  - Changed frontend service port mapping from "80:3000" to "3000:3000" to free up port 80 for Nginx

## Testing
- **What was tested**:
  - Verified frontend container starts correctly with new port binding
  - Confirmed Nginx can now successfully bind to port 80 without conflict
  - Checked access to frontend via reverse proxy at http://raina-moon.com
- **Known Issues**:
  - None

## Fix
- Resolved Nginx startup failure caused by Docker occupying port 80
- Ensured cleaner separation of frontend service and Nginx proxy responsibilities