### PR TITLE
🚑 fix: update frontend env_file to use .env.production for production…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     depends_on:
       - backend
     env_file:
-      - ./frontend/.env
+      - ./frontend/.env.production
 
 volumes:
   postgres_data:


### PR DESCRIPTION
# Pull Request Template

## Overview
- **Purpose of this PR**: Update Docker Compose configuration to use the correct production environment variables for frontend deployment.
- **Related Issue**: None

## Changes
- Updated docker-compose.yml to reference ./frontend/.env.production instead of the default .env file
- Ensured production-specific variables (e.g., NEXT_PUBLIC_API_URL) are applied during frontend container build

## Testing
- **What was tested**:
  - Verified frontend correctly pulls NEXT_PUBLIC_API_URL from .env.production
  - Confirmed API requests are routed to the correct backend endpoint
- **Known Issues**:
  - None

## Fix
- Fixed incorrect environment file usage that was previously causing undefined API URLs in production
- Ensured Docker uses the intended production env file to avoid Mixed Content errors

