### PR TITLE
🚑 fix: add include path to tsconfig.json for TypeScript compilation

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -7,7 +7,8 @@
   "forceConsistentCasingInFileNames": true,
   "strict": true,
   "skipLibCheck": true
-}
+},
+"include": ["src/**/*"]
 
 }
 // 


### PR DESCRIPTION
# Pull Request Template

## Overview
- **Purpose of this PR**: Ensure TypeScript compiles all necessary files in the backend
- **Related Issue**: None

## Changes
- Added "include": ["src/**/*"] to tsconfig.json in the backend
- This change ensures all .ts files inside src/ are properly compiled to the dist/ directory

## Testing
- **What was tested**:
  - Confirmed that contact.js and other route files are correctly compiled to the dist/ folder
  - Backend successfully recognized /api/contact route after rebuild
- **Known Issues**:
  - None

## Fix
- The backend previously failed to serve routes like /api/contact due to missing compiled output
- This fix adds the necessary include directive to ensure all relevant TypeScript files are compiled during the build step