### PR TITLE
Fix/UI

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "@tiptap/react": "^2.12.0",
     "@tiptap/starter-kit": "^2.12.0",
     "framer-motion": "^12.23.12",
+    "gsap": "^3.13.0",
     "lucide-react": "^0.539.0",
     "next": "^15.4.6",
     "react": "^19.0.0",

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -214,11 +214,11 @@ const Page = () => {
       <div className="flex flex-col gap-4 lg:gap-6 w-full">
         <section
           ref={horizRef}
-          className="block w-full flex-none relative overflow-hidden my-6 lg:my-20 bg-blue-50"
+          className="block w-full md:w-screen flex-none relative overflow-visible md:overflow-hidden my-6 lg:my-20 bg-blue-50"
         >
           <div
             ref={stripRef}
-            className="flex flex-nowrap items-stretch gap-6 px-5 md:px-10 pt-10 pb-20 lg:pt-20 lg:pb-40"
+            className="flex flex-col md:flex-row md:flex-nowrap items-stretch gap-6 px-5 md:px-10 pt-10 pb-20 lg:pt-20 lg:pb-40"
           >
             <Description lang={lang} mode="horizontal" />
           </div>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -11,7 +11,9 @@ import React, { useEffect, useLayoutEffect, useRef } from "react";
 import { FaGithub, FaLinkedin } from "react-icons/fa";
 import gsap from "gsap";
 import { ScrollTrigger } from "gsap/ScrollTrigger";
+
 gsap.registerPlugin(ScrollTrigger);
+
 const Page = () => {
   const { lang } = useLanguageStore();
 
@@ -51,7 +53,7 @@ const Page = () => {
           if (entry.isIntersecting) {
             entry.target.classList.add("animate-fade-in");
             entry.target.classList.remove("opacity-0");
-            observer.unobserve(entry.target); // Stop observing once the element is in view
+            observer.unobserve(entry.target);
           }
         });
       },
@@ -61,7 +63,6 @@ const Page = () => {
     const descItems = document.querySelectorAll(".desc-item");
     descItems.forEach((item) => observer.observe(item));
 
-    // Initial check for items already in viewport
     descItems.forEach((item) => {
       const rect = item.getBoundingClientRect();
       if (rect.top >= 0 && rect.top <= window.innerHeight * 0.8) {
@@ -78,43 +79,48 @@ const Page = () => {
     };
   }, [lang]);
 
- useLayoutEffect(() => {
-  const wrapper = horizRef.current!;
-  const strip = stripRef.current!;
-  const ctx = gsap.context(() => {
-    ScrollTrigger.matchMedia({
-      "(min-width: 768px)": () => {
-        const distance = () => Math.max(0, strip.scrollWidth - window.innerWidth);
+  useLayoutEffect(() => {
+    const wrapper = horizRef.current!;
+    const strip = stripRef.current!;
+    const ctx = gsap.context(() => {
+      ScrollTrigger.matchMedia({
+        "(min-width: 768px)": () => {
+          if (!wrapper || !strip) return;
 
-        const tween = gsap.to(strip, {
-          x: () => -distance(),
-          ease: "none",
-          scrollTrigger: {
-            trigger: wrapper,
-            start: "top top",
-            end: () => `+=${distance()}`,
-            pin: true,
-            scrub: true,
-            anticipatePin: 1,
-            invalidateOnRefresh: true,
-          },
-        });
+          const distance = () =>
+            Math.max(0, strip.scrollWidth - wrapper.clientWidth);
 
-        const onRefreshInit = () => { gsap.set(strip, { x: 0 }); }; // ← 반환 없음
-        ScrollTrigger.addEventListener("refreshInit", onRefreshInit);
+          const tween = gsap.to(strip, {
+            x: () => -distance(),
+            ease: "none",
+            scrollTrigger: {
+              trigger: wrapper,
+              start: "top top",
+              end: () => `+=${distance()}`,
+              pin: true,
+              pinSpacing: true,
+              pinReparent: true,
+              scrub: 1,
+              anticipatePin: 1,
+              invalidateOnRefresh: true,
+            },
+          });
 
-        return () => {
-          ScrollTrigger.removeEventListener("refreshInit", onRefreshInit); // 깔끔히 해제
-          tween.scrollTrigger?.kill();
-          tween.kill();
-        };
-      },
-    });
-  }, wrapper);
-  return () => ctx.revert();
-}, []);
+          const onRefreshInit = () => {
+            gsap.set(strip, { x: 0 });
+          };
+          ScrollTrigger.addEventListener("refreshInit", onRefreshInit);
 
-
+          return () => {
+            ScrollTrigger.removeEventListener("refreshInit", onRefreshInit);
+            tween.scrollTrigger?.kill();
+            tween.kill();
+          };
+        },
+      });
+    }, wrapper);
+    return () => ctx.revert();
+  }, []);
 
   const renderTitle = () => {
     if (lang === "en") {
@@ -208,7 +214,7 @@ const Page = () => {
       <div className="flex flex-col gap-4 lg:gap-6 w-full">
         <section
           ref={horizRef}
-          className="relative w-screen overflow-hidden my-6 lg:my-20 bg-blue-50"
+          className="block w-full flex-none relative overflow-hidden my-6 lg:my-20 bg-blue-50"
         >
           <div
             ref={stripRef}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -7,14 +7,19 @@ import ScrollToTopButton from "@/components/ScrollToTopButton";
 import SkillsTable from "@/components/SkillsTable/SkillsTable";
 import { useLanguageStore } from "@/libs/languageStore";
 import Image from "next/image";
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useLayoutEffect, useRef } from "react";
 import { FaGithub, FaLinkedin } from "react-icons/fa";
-
+import gsap from "gsap";
+import { ScrollTrigger } from "gsap/ScrollTrigger";
+gsap.registerPlugin(ScrollTrigger);
 const Page = () => {
   const { lang } = useLanguageStore();
 
   const headerRef = useRef<HTMLDivElement>(null);
   const descRef = useRef<HTMLDivElement>(null);
+
+  const horizRef = useRef<HTMLDivElement>(null);
+  const stripRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const handleScroll = () => {
@@ -73,6 +78,44 @@ const Page = () => {
     };
   }, [lang]);
 
+ useLayoutEffect(() => {
+  const wrapper = horizRef.current!;
+  const strip = stripRef.current!;
+  const ctx = gsap.context(() => {
+    ScrollTrigger.matchMedia({
+      "(min-width: 768px)": () => {
+        const distance = () => Math.max(0, strip.scrollWidth - window.innerWidth);
+
+        const tween = gsap.to(strip, {
+          x: () => -distance(),
+          ease: "none",
+          scrollTrigger: {
+            trigger: wrapper,
+            start: "top top",
+            end: () => `+=${distance()}`,
+            pin: true,
+            scrub: true,
+            anticipatePin: 1,
+            invalidateOnRefresh: true,
+          },
+        });
+
+        const onRefreshInit = () => { gsap.set(strip, { x: 0 }); }; // ← 반환 없음
+        ScrollTrigger.addEventListener("refreshInit", onRefreshInit);
+
+        return () => {
+          ScrollTrigger.removeEventListener("refreshInit", onRefreshInit); // 깔끔히 해제
+          tween.scrollTrigger?.kill();
+          tween.kill();
+        };
+      },
+    });
+  }, wrapper);
+  return () => ctx.revert();
+}, []);
+
+
+
   const renderTitle = () => {
     if (lang === "en") {
       return (
@@ -121,8 +164,10 @@ const Page = () => {
             alt="profile image"
             width={380}
             height={380}
-            className={`${lang === "en" ? "absolute right-[28px] w-[150px] sm:top-2 sm:w-[230px] sm:right-[33px] md:top-4 md:right-[55px] md:w-[250px] lg:w-[340px] lg:top-6 lg:right-[85px] xl:top-8 xl:right-[110px] xl:w-[380px]"
-              : "absolute right-[14px] w-[150px] sm:top-2 sm:w-[230px] sm:right-[33px] md:top-4 md:right-[55px] md:w-[250px] lg:w-[340px] lg:top-6 lg:right-[85px] xl:top-8 xl:right-[110px] xl:w-[380px]"
+            className={`${
+              lang === "en"
+                ? "absolute right-[28px] w-[150px] sm:top-2 sm:w-[230px] sm:right-[33px] md:top-4 md:right-[55px] md:w-[250px] lg:w-[340px] lg:top-6 lg:right-[85px] xl:top-8 xl:right-[110px] xl:w-[380px]"
+                : "absolute right-[14px] w-[150px] sm:top-2 sm:w-[230px] sm:right-[33px] md:top-4 md:right-[55px] md:w-[250px] lg:w-[340px] lg:top-6 lg:right-[85px] xl:top-8 xl:right-[110px] xl:w-[380px]"
             }`}
           />
           <strong className="text-[60px] sm:text-[100px] md:text-[120px] lg:text-[170px] xl:text-[200px] text-gray-900">
@@ -161,15 +206,17 @@ const Page = () => {
       </div>
 
       <div className="flex flex-col gap-4 lg:gap-6 w-full">
-        <div
-          ref={descRef}
-          className="bg-blue-50 my-6 lg:my-20 z-10 transition-transform duration-300 w-full"
+        <section
+          ref={horizRef}
+          className="relative w-screen overflow-hidden my-6 lg:my-20 bg-blue-50"
         >
-          <div className="pt-10 pb-20 lg:pt-20 lg:pb-40">
-            {" "}
-            <Description lang={lang} />
+          <div
+            ref={stripRef}
+            className="flex flex-nowrap items-stretch gap-6 px-5 md:px-10 pt-10 pb-20 lg:pt-20 lg:pb-40"
+          >
+            <Description lang={lang} mode="horizontal" />
           </div>
-        </div>
+        </section>
 
         <SkillsTable />
 

--- a/frontend/src/components/ContactForm/ContactForm.tsx
+++ b/frontend/src/components/ContactForm/ContactForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useRef } from "react";
-import { motion, AnimatePresence } from "framer-motion";
+import { motion } from "framer-motion";
 import { toast } from "react-toastify";
 import { sendContactMessage } from "@/libs/api/contact";
 import { Send, XCircle } from "lucide-react";

--- a/frontend/src/components/Description/Description.tsx
+++ b/frontend/src/components/Description/Description.tsx
@@ -95,7 +95,6 @@ const Description: React.FC<DescriptionProps> = ({
   const slideClass = "w-[85vw] md:w-[70vw] xl:w-[900px] mx-5 md:mx-10 shrink-0";
 
   if (mode === "horizontal") {
-    // 수평: 래퍼 div 없이 슬라이드만 반환
     return (
       <>
         {lang === "en" ? (

--- a/frontend/src/components/Description/Description.tsx
+++ b/frontend/src/components/Description/Description.tsx
@@ -85,9 +85,150 @@ const DescriptionItem: React.FC<DescriptionItemProps> = ({
 
 interface DescriptionProps {
   lang: "en" | "ko";
+  mode?: "vertical" | "horizontal";
 }
 
-const Description: React.FC<DescriptionProps> = ({ lang }) => {
+const Description: React.FC<DescriptionProps> = ({
+  lang,
+  mode = "vertical",
+}) => {
+  const slideClass = "w-[85vw] md:w-[70vw] xl:w-[900px] mx-5 md:mx-10 shrink-0";
+
+  if (mode === "horizontal") {
+    // 수평: 래퍼 div 없이 슬라이드만 반환
+    return (
+      <>
+        {lang === "en" ? (
+          <>
+            <DescriptionItem
+              imageSrc="/images/image_01.png"
+              imageAlt="Developer Icon"
+              isMobileImageHidden
+              containerClassName={slideClass}
+              textContent={
+                <div className="flex flex-col gap-2">
+                  <p className="leading-relaxed text-gray-700 text-lg md:text-xl">
+                    Hi, I&#39;m{" "}
+                    <span
+                      className="font-bold text-primary-600"
+                      style={{ textShadow: "0 0 5px rgba(97, 157, 253, 0.7)" }}
+                    >
+                      Raina Moon
+                    </span>
+                    — a <span className="font-bold">frontend developer</span>{" "}
+                    who thrives on solving{" "}
+                    <span className="font-semibold">real problems</span> through{" "}
+                    <span className="underline underline-offset-4">
+                      intuitive interfaces
+                    </span>
+                    .
+                  </p>
+                  <p className="leading-relaxed text-gray-600 md:text-lg">
+                    With experience building projects from the ground up, I
+                    focus on <span className="font-semibold">clean design</span>
+                    , <span className="font-semibold">solid architecture</span>,
+                    and <span className="font-semibold">human-centered UX</span>
+                    .
+                  </p>
+                </div>
+              }
+            />
+            <DescriptionItem
+              imageSrc="/images/image_02.png"
+              imageAlt="Tech Icon"
+              isMobileImageHidden
+              isImageLeft
+              imageClassName="rounded-xl lg:rounded-3xl"
+              containerClassName={slideClass}
+              textContent={
+                <p className="leading-relaxed text-gray-700 font-medium text-lg md:text-xl flex-1">
+                  I build with <span className="font-bold">Next.js</span>,{" "}
+                  <span className="font-bold">TypeScript</span>, and{" "}
+                  <span className="font-bold">TailwindCSS</span>, and I&#39;m
+                  expanding my full-stack skills using{" "}
+                  <span className="font-bold">Node.js</span> and{" "}
+                  <span className="font-bold">PostgreSQL</span>.
+                </p>
+              }
+            />
+            <DescriptionItem
+              imageSrc="/images/image_03.png"
+              imageAlt="Mobile Icon"
+              isMobileImageHidden
+              imageClassName="rounded-xl lg:rounded-3xl"
+              containerClassName={slideClass}
+              textContent={
+                <p className="leading-relaxed text-gray-600 italic text-lg md:text-xl flex-1">
+                  Recently, I&#39;ve also started learning{" "}
+                  <span className="font-bold">React Native</span> to explore{" "}
+                  <span className="italic">mobile development</span>.
+                </p>
+              }
+            />
+          </>
+        ) : (
+          <>
+            <DescriptionItem
+              imageSrc="/images/image_01.png"
+              imageAlt="개발자 아이콘"
+              isMobileImageHidden
+              containerClassName={slideClass}
+              textContent={
+                <div className="flex flex-col gap-2">
+                  <p className="leading-relaxed text-gray-700 text-lg md:text-xl flex-1">
+                    안녕하세요, 저는 빠르게 성장하고 실행력 있게 움직이는{" "}
+                    <span className="font-bold text-primary-600">
+                      프론트엔드 개발자 Raina
+                    </span>
+                    입니다.
+                  </p>
+                  <p className="leading-relaxed text-gray-600 text-lg md:text-xl flex-1">
+                    다양한 프로젝트를 직접 기획하고 구현하며,{" "}
+                    <span className="font-semibold">문제 해결</span>과{" "}
+                    <span className="font-semibold">사용자 경험</span>을
+                    중심으로 코드를 작성합니다.
+                  </p>
+                </div>
+              }
+            />
+            <DescriptionItem
+              imageSrc="/images/image_02.png"
+              imageAlt="기술 아이콘"
+              isMobileImageHidden
+              isImageLeft
+              imageClassName="rounded-xl lg:rounded-3xl"
+              containerClassName={slideClass}
+              textContent={
+                <p className="leading-relaxed text-gray-700 font-medium text-lg md:text-xl flex-1">
+                  현재는 <span className="font-bold">Next.js</span>,{" "}
+                  <span className="font-bold">TypeScript</span>,{" "}
+                  <span className="font-bold">TailwindCSS</span>를 활용해 웹을
+                  만들고 있으며, <span className="font-bold">Node.js</span>와{" "}
+                  <span className="font-bold">PostgreSQL</span>로 백엔드 역량도
+                  키우는 중입니다.
+                </p>
+              }
+            />
+            <DescriptionItem
+              imageSrc="/images/image_03.png"
+              imageAlt="모바일 아이콘"
+              isMobileImageHidden
+              imageClassName="rounded-xl lg:rounded-3xl"
+              containerClassName={slideClass}
+              textContent={
+                <p className="leading-relaxed text-gray-600 italic text-lg md:text-xl flex-1">
+                  최근에는 <span className="font-bold">React Native</span>를
+                  공부하며 <span className="font-bold">모바일 개발</span>에도
+                  도전하고 있어요.
+                </p>
+              }
+            />
+          </>
+        )}
+      </>
+    );
+  }
+
   return (
     <div className="flex flex-col items-center justify-center mx-5 md:mx-10 gap-8 lg:gap-12">
       {lang === "en" ? (

--- a/frontend/src/components/Description/Description.tsx
+++ b/frontend/src/components/Description/Description.tsx
@@ -92,9 +92,8 @@ const Description: React.FC<DescriptionProps> = ({
   lang,
   mode = "vertical",
 }) => {
-  const slideClass =
-    "w-full md:w-[70vw] xl:w-[900px] mx-5 md:mx-10 md:shrink-0";
-
+const slideClass = "w-full mx-auto px-5 md:px-10";
+  
   if (mode === "horizontal") {
     return (
       <>

--- a/frontend/src/components/Description/Description.tsx
+++ b/frontend/src/components/Description/Description.tsx
@@ -92,7 +92,8 @@ const Description: React.FC<DescriptionProps> = ({
   lang,
   mode = "vertical",
 }) => {
-  const slideClass = "w-[85vw] md:w-[70vw] xl:w-[900px] mx-5 md:mx-10 shrink-0";
+  const slideClass =
+    "w-full md:w-[70vw] xl:w-[900px] mx-5 md:mx-10 md:shrink-0";
 
   if (mode === "horizontal") {
     return (

--- a/frontend/src/components/HorizontalScroller.tsx
+++ b/frontend/src/components/HorizontalScroller.tsx
@@ -8,7 +8,7 @@ gsap.registerPlugin(ScrollTrigger);
 
 type Props = {
   children: React.ReactNode;
-  start?: string; // 필요시 "top top" 등 조정
+  start?: string;
 };
 
 export default function HorizontalScroller({ children, start = "top top" }: Props) {
@@ -20,7 +20,6 @@ export default function HorizontalScroller({ children, start = "top top" }: Prop
     const strip = stripRef.current!;
 
     const ctx = gsap.context(() => {
-      // 데스크톱 이상에서만 가로 스크롤 (모바일은 기본 세로)
       ScrollTrigger.matchMedia({
         "(min-width: 768px)": () => {
           const tween = gsap.to(strip, {
@@ -29,7 +28,7 @@ export default function HorizontalScroller({ children, start = "top top" }: Prop
             scrollTrigger: {
               trigger: wrapper,
               start,
-              end: () => `+=${strip.scrollWidth}`, // 콘텐츠 길이만큼 스크롤
+              end: () => `+=${strip.scrollWidth}`,
               scrub: true,
               pin: true,
               anticipatePin: 1,
@@ -37,7 +36,6 @@ export default function HorizontalScroller({ children, start = "top top" }: Prop
             },
           });
 
-          // 리사이즈 시 초기화
           ScrollTrigger.addEventListener("refreshInit", () => {
             gsap.set(strip, { x: 0 });
           });

--- a/frontend/src/components/HorizontalScroller.tsx
+++ b/frontend/src/components/HorizontalScroller.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useLayoutEffect, useRef } from "react";
+import gsap from "gsap";
+import { ScrollTrigger } from "gsap/ScrollTrigger";
+
+gsap.registerPlugin(ScrollTrigger);
+
+type Props = {
+  children: React.ReactNode;
+  start?: string; // 필요시 "top top" 등 조정
+};
+
+export default function HorizontalScroller({ children, start = "top top" }: Props) {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const stripRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    const wrapper = wrapperRef.current!;
+    const strip = stripRef.current!;
+
+    const ctx = gsap.context(() => {
+      // 데스크톱 이상에서만 가로 스크롤 (모바일은 기본 세로)
+      ScrollTrigger.matchMedia({
+        "(min-width: 768px)": () => {
+          const tween = gsap.to(strip, {
+            x: () => -(strip.scrollWidth - window.innerWidth),
+            ease: "none",
+            scrollTrigger: {
+              trigger: wrapper,
+              start,
+              end: () => `+=${strip.scrollWidth}`, // 콘텐츠 길이만큼 스크롤
+              scrub: true,
+              pin: true,
+              anticipatePin: 1,
+              invalidateOnRefresh: true,
+            },
+          });
+
+          // 리사이즈 시 초기화
+          ScrollTrigger.addEventListener("refreshInit", () => {
+            gsap.set(strip, { x: 0 });
+          });
+
+          return () => {
+            tween.scrollTrigger?.kill();
+            tween.kill();
+          };
+        },
+      });
+    }, wrapper);
+
+    return () => ctx.revert();
+  }, []);
+
+  return (
+    <section ref={wrapperRef} className="relative w-screen overflow-hidden">
+      <div ref={stripRef} className="flex flex-nowrap will-change-transform">
+        {children}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
# Pull Request Template

## Overview
- Purpose of this PR: Implement desktop-only horizontal scrolling section for the Description cards using GSAP + ScrollTrigger, while keeping mobile/tablet as vertical stacks. Improves portfolio UX: vertical → horizontal (3 slides) → vertical.
- Related Issue: None

## Changes
- Introduced desktop-only horizontal scroll behavior in page.tsx:
  - Added horizRef (wrapper) and stripRef (inner strip) and a GSAP useLayoutEffect that pins the wrapper and translates the strip on scroll (translateX).
  - Enabled only under media query "(min-width: 1280px) and (hover: hover) and (pointer: fine)" to exclude iPad/tablets and touch devices.
  - Used distance = strip.scrollWidth - wrapper.clientWidth for accurate travel length.
  - Set pin: true, pinSpacing: true, pinReparent: true, scrub: 1, anticipatePin: 1, invalidateOnRefresh: true.
  - Fixed refresh jitter with refreshInit listener that resets x to 0 before recalculation.
- Refactored layout classes to swap between vertical and horizontal:
  - stripRef container now toggles:
    - Vertical (default/mobile/tablet): flex-col items-center [&>.desc-item]:w-full [&>.desc-item]:max-w-[900px] [&>.desc-item]:mx-auto.
    - Horizontal (desktop): flex-row flex-nowrap [&>.desc-item]:shrink-0 [&>.desc-item]:w-[70vw] xl:[&>.desc-item]:w-[900px].
  - Section wrapper uses overflow-visible on mobile/tablet and overflow-hidden on desktop.
- Updated Description component to support mode="horizontal" (content-only).
  - Simplified slideClass to vertical-first (w-full mx-auto px-5 md:px-10); horizontal widths are now applied by the parent strip via utility selectors.
- Kept existing header parallax/IntersectionObserver but decoupled it from the horizontal section to avoid transform conflicts.
- TypeScript fix: ScrollTrigger.addEventListener("refreshInit", onRefreshInit) now uses a block body callback (returns void) and cleans up with removeEventListener to prevent type errors and leaks.

## Testing
- What was tested:
  - Desktop (≥1280px, mouse): horizontal scroll pins correctly; three slides translate smoothly; following sections don’t scroll while pinned.
  - iPad Pro / tablets / touch laptops: falls back to vertical stack (all three cards centered and fully visible).
  - Mobile phones: vertical stack with proper spacing; no horizontal overflow.
  - Resize/rotate: invalidateOnRefresh + refreshInit ensures correct recalculation; no leftover transforms.
  - Accessibility: honors input type (no forced horizontal on touch); verified keyboard scroll continues to work.
- Known Issues:
  - If slide images load late, width can change. We call ScrollTrigger.refresh() on window.load, but in rare cases (very large images or custom loaders) a manual refresh might be needed after content swaps.
  - prefers-reduced-motion is not yet handled (could add a guard to disable the tween for users who prefer reduced motion).

## Fix
- Fixes #18 