### PR TITLE
Fix/UI

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -5,3 +5,167 @@
 html {
   scroll-behavior: smooth;
 }
+
+/* ===== Glowing Edge Card ===== */
+:root{
+  --glow-sens: 20;
+  --blend: soft-light;
+  --glow-blend: plus-lighter;
+  --glow-color: 40deg 80% 80%;
+}
+
+.glow-card{
+  /* 레이아웃/모양 */
+  position: relative;
+  isolation: isolate;              /* 의사요소 겹침 안정화 */
+  border-radius: 1.5rem;           /* Tailwind의 rounded-3xl와 일치 */
+  border: 1px solid rgb(255 255 255 / 25%);
+  background: linear-gradient(8deg, hsl(260 10% 12%) 75%, hsl(260 10% 14%) 75.5%);
+  transition: box-shadow .25s ease-out, filter .25s ease-out;
+  overflow: hidden;
+    --edge: 50px;   /* 엣지 색 두께 (작게=테두리 얇음, 크게=두꺼움) */
+
+  /* 효과 관련 변수 */
+  --color-sens: calc(var(--glow-sens) + 20);
+}
+
+/* hover 시 기본 카드 반응 (선택) */
+.glow-card:hover{
+  filter: brightness(1.04);
+  box-shadow:
+    0 1px 2px rgba(0,0,0,.08),
+    0 8px 24px rgba(0,0,0,.18);
+}
+
+/* 공통: 의사요소와 .glow의 기본 세팅 */
+.glow-card::before{
+  border: 1px solid transparent;
+  background:
+    linear-gradient(#0000 0 100%) border-box,
+    radial-gradient(at 80% 55%, hsl(268 100% 76%) 0, transparent 50%) border-box,
+    radial-gradient(at 69% 34%, hsl(349 100% 74%) 0, transparent 50%) border-box,
+    radial-gradient(at  8%  6%, hsl(136 100% 78%) 0, transparent 50%) border-box,
+    radial-gradient(at 41% 38%, hsl(192 100% 64%) 0, transparent 50%) border-box,
+    radial-gradient(at 86% 85%, hsl(186 100% 74%) 0, transparent 50%) border-box,
+    radial-gradient(at 82% 18%, hsl( 52 100% 65%) 0, transparent 50%) border-box,
+    radial-gradient(at 51%  4%, hsl( 12 100% 72%) 0, transparent 50%) border-box,
+    linear-gradient(#c299ff 0 100%) border-box;
+
+  /* 엣지 근접도에 따라 투명도 */
+  opacity: calc((var(--pointer-d,0) - var(--color-sens)) / (100 - var(--color-sens)));
+
+  /* --- 여기부터 마스크를 '엣지 링' ∩ '포인터 방향 콘'으로 교차 --- */
+  mask-image:
+    var(--ring),
+    conic-gradient(from var(--pointer-°,0deg) at center, #000 25%, #0000 40% 60%, #000 75%);
+  /* 표준 */
+  mask-composite: intersect;
+  /* Safari/WebKit 교차(Intersection) 대체 */
+  -webkit-mask-image:
+    var(--ring),
+    conic-gradient(from var(--pointer-°,0deg) at center, #000 25%, #0000 40% 60%, #000 75%);
+  -webkit-mask-composite: source-over, source-in;
+}
+.glow-card::after{
+  border: 1px solid transparent;
+  background:
+    radial-gradient(at 80% 55%, hsl(268 100% 76%) 0, transparent 50%) padding-box,
+    radial-gradient(at 69% 34%, hsl(349 100% 74%) 0, transparent 50%) padding-box,
+    radial-gradient(at  8%  6%, hsl(136 100% 78%) 0, transparent 50%) padding-box,
+    radial-gradient(at 41% 38%, hsl(192 100% 64%) 0, transparent 50%) padding-box,
+    radial-gradient(at 86% 85%, hsl(186 100% 74%) 0, transparent 50%) padding-box,
+    radial-gradient(at 82% 18%, hsl( 52 100% 65%) 0, transparent 50%) padding-box,
+    radial-gradient(at 51%  4%, hsl( 12 100% 72%) 0, transparent 50%) padding-box,
+    linear-gradient(#c299ff 0 100%) padding-box;
+
+  opacity: calc((var(--pointer-d,0) - var(--color-sens)) / (100 - var(--color-sens)));
+  mix-blend-mode: var(--blend);
+
+  /* --- 엣지 링 ∩ 포인터 방향 콘 --- */
+  mask-image:
+    var(--ring),
+    conic-gradient(from var(--pointer-°,0deg) at center, #0000 5%, #000 15% 85%, #0000 95%);
+  mask-composite: intersect;
+
+  -webkit-mask-image:
+    var(--ring),
+    conic-gradient(from var(--pointer-°,0deg) at center, #0000 5%, #000 15% 85%, #0000 95%);
+  -webkit-mask-composite: source-over, source-in;
+}
+.glow-card > .glow{
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  transition: opacity .25s ease-out;
+  z-index: -1; /* 배경에서 동작 */
+    --outset: 100px; /* 커질수록 바깥으로 더 퍼짐 */
+}
+
+/* 포인터가 멀면 자연스럽게 사라지게 */
+.glow-card:not(:hover):not(.glow-animating)::before,
+.glow-card:not(:hover):not(.glow-animating)::after,
+.glow-card:not(:hover):not(.glow-animating) > .glow{
+  opacity: 0;
+  transition: opacity .6s ease-in-out;
+}
+
+/* ::after — 내부 메시 배경 + 스퀴클 컷아웃 + 원뿔 마스크 */
+.glow-card::after{
+  border: 1px solid transparent;
+  background:
+    radial-gradient(at 80% 55%, hsl(268 100% 76%) 0, transparent 50%) padding-box,
+    radial-gradient(at 69% 34%, hsl(349 100% 74%) 0, transparent 50%) padding-box,
+    radial-gradient(at  8%  6%, hsl(136 100% 78%) 0, transparent 50%) padding-box,
+    radial-gradient(at 41% 38%, hsl(192 100% 64%) 0, transparent 50%) padding-box,
+    radial-gradient(at 86% 85%, hsl(186 100% 74%) 0, transparent 50%) padding-box,
+    radial-gradient(at 82% 18%, hsl( 52 100% 65%) 0, transparent 50%) padding-box,
+    radial-gradient(at 51%  4%, hsl( 12 100% 72%) 0, transparent 50%) padding-box,
+    linear-gradient(#c299ff 0 100%) padding-box;
+  mask-image:
+    linear-gradient(#000, #000),
+    radial-gradient(ellipse at 50% 50%, #000 40%, #0000 65%),
+    radial-gradient(ellipse at 66% 66%, #000 5%, #0000 40%),
+    radial-gradient(ellipse at 33% 33%, #000 5%, #0000 40%),
+    radial-gradient(ellipse at 66% 33%, #000 5%, #0000 40%),
+    radial-gradient(ellipse at 33% 66%, #000 5%, #0000 40%),
+    conic-gradient(from var(--pointer-°,0deg) at center, #0000 5%, #000 15% 85%, #0000 95%);
+  /* 사파리 호환용 */
+  -webkit-mask-composite: destination-out, source-over, source-over, source-over, source-over, source-over, source-over;
+  mask-composite: subtract, add, add, add, add, add;
+
+  opacity: calc((var(--pointer-d,0) - var(--color-sens)) / (100 - var(--color-sens)));
+  mix-blend-mode: var(--blend);
+}
+
+/* .glow — 바깥쪽 글로우 (outset 패딩으로 넘치게) */
+.glow-card > .glow{
+  --outset: 40px;
+  inset: calc(var(--outset) * -1);
+  pointer-events: none;
+  z-index: 1;
+  mask-image: conic-gradient(from var(--pointer-°,0deg) at center, #000 2.5%, #0000 10% 90%, #000 97.5%);
+  opacity: calc((var(--pointer-d,0) - var(--glow-sens)) / (100 - var(--glow-sens)));
+  mix-blend-mode: var(--glow-blend);
+}
+
+.glow-card > .glow::before{
+  content:"";
+  position: absolute;
+  inset: var(--outset);
+  border-radius: inherit;
+  box-shadow:
+    inset 0 0 0 1px hsl(var(--glow-color) / 1),
+    inset 0 0 2px 2px hsl(var(--glow-color) / .9),
+    inset 0 0 5px 1px hsl(var(--glow-color) / .75),
+    inset 0 0 8px 1px hsl(var(--glow-color) / .66),
+    inset 0 0 15px 0 hsl(var(--glow-color) / .5),
+    inset 0 0 25px 2px hsl(var(--glow-color) / .3),
+    inset 0 0 50px 2px hsl(var(--glow-color) / .1),
+    0 0 2px 2px hsl(var(--glow-color) / .9),
+    0 0 5px 1px hsl(var(--glow-color) / .75),
+    0 0 8px 1px hsl(var(--glow-color) / .66),
+    0 0 15px 0 hsl(var(--glow-color) / .5),
+    0 0 25px 2px hsl(var(--glow-color) / .3),
+    0 0 50px 2px hsl(var(--glow-color) / .1);
+}

--- a/frontend/src/components/Description/Description.tsx
+++ b/frontend/src/components/Description/Description.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback, useRef } from "react";
 import { motion } from "framer-motion";
 
 interface DescriptionItemProps {
@@ -20,37 +20,70 @@ const DescriptionItem: React.FC<DescriptionItemProps> = ({
   imageClassName = "",
   containerClassName = "",
 }) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  const handlePointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const el = ref.current;
+    if (!el) return;
+
+    const rect = el.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+
+    const px = (x / rect.width) * 100;
+    const py = (y / rect.height) * 100;
+
+    const cx = rect.width / 2;
+    const cy = rect.height / 2;
+    const dx = x - cx;
+    const dy = y - cy;
+
+    let angle = Math.atan2(dy, dx) * (180 / Math.PI) + 90;
+    if (angle < 0) angle += 360;
+
+    const kx = dx !== 0 ? cx / Math.abs(dx) : Number.POSITIVE_INFINITY;
+    const ky = dy !== 0 ? cy / Math.abs(dy) : Number.POSITIVE_INFINITY;
+    const edge = Math.min(kx, ky);
+    const closeness = Math.max(0, Math.min(1, 1 / edge)); // 0~1
+
+    el.style.setProperty("--pointer-x", `${px.toFixed(2)}%`);
+    el.style.setProperty("--pointer-y", `${py.toFixed(2)}%`);
+    el.style.setProperty("--pointer-°", `${angle.toFixed(2)}deg`);
+    el.style.setProperty("--pointer-d", `${(closeness * 100).toFixed(2)}`);
+    el.classList.remove("glow-animating");
+  }, []);
+
+  const handlePointerLeave = useCallback(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.style.setProperty("--pointer-d", "0");
+  }, []);
+
   return (
     <motion.div
-      className={`desc-item flex flex-col md:grid md:grid-cols-2 items-center justify-center gap-6 px-5 py-6 lg:gap-10 lg:px-14 lg:py-10 bg-gradient-to-br from-white to-gray-50 rounded-3xl shadow-lg opacity-0 max-w-[900px] ${containerClassName} relative overflow-hidden`}
+      ref={ref}
+      className={`glow-card desc-item flex flex-col md:grid md:grid-cols-2 items-center justify-center gap-6 px-5 py-6 lg:gap-10 lg:px-14 lg:py-10 bg-gradient-to-br from-white/5 to-gray-50/5 rounded-3xl shadow-lg max-w-[900px] ${containerClassName} relative`}
       initial={{ opacity: 0, y: 20 }}
       whileInView={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.6 }}
       viewport={{ once: true }}
-      whileHover={{
-        boxShadow:
-          "0 0 20px rgba(255, 105, 180, 0.7), 0 0 40px rgba(0, 191, 255, 0.7)",
-        filter: "brightness(1.1)",
-        transition: { duration: 0.3 },
-      }}
-      style={{
-        boxShadow: "0 4px 6px rgba(0, 0, 0, 0.1)",
-        border: "1px solid transparent",
-        background:
-          "linear-gradient(white, white) padding-box, conic-gradient(red, orange, yellow, green, blue, indigo, violet, red) border-box",
-      }}
+
+      onPointerMove={handlePointerMove}
+      onPointerLeave={handlePointerLeave}
     >
+      {/* 바깥쪽 글로우 레이어 */}
+      <span className="glow" aria-hidden />
+
       <motion.img
         src={imageSrc}
         alt={imageAlt}
         className={`w-[230px] md:w-full ${
-          isMobileImageHidden
-            ? "rounded-xl md:hidden"
-            : "rounded-xl md:rounded-2xl"
+          isMobileImageHidden ? "rounded-xl md:hidden" : "rounded-xl md:rounded-2xl"
         } ${imageClassName}`}
         whileHover={{ scale: 1.05, rotate: 2 }}
         transition={{ duration: 0.3 }}
       />
+
       {isImageLeft ? (
         <>
           <motion.img
@@ -60,16 +93,11 @@ const DescriptionItem: React.FC<DescriptionItemProps> = ({
             whileHover={{ scale: 1.05, rotate: 2 }}
             transition={{ duration: 0.3 }}
           />
-          <div className="flex flex-col gap-2 leading-relaxed">
-            {textContent}
-          </div>
+          <div className="flex flex-col gap-2 leading-relaxed">{textContent}</div>
         </>
       ) : (
         <>
-          <div className="flex flex-col gap-2 leading-relaxed">
-            {textContent}
-          </div>
-
+          <div className="flex flex-col gap-2 leading-relaxed">{textContent}</div>
           <motion.img
             src={imageSrc}
             alt={imageAlt}
@@ -106,10 +134,10 @@ const slideClass = "w-full mx-auto px-5 md:px-10";
               containerClassName={slideClass}
               textContent={
                 <div className="flex flex-col gap-2">
-                  <p className="leading-relaxed text-gray-700 text-lg md:text-xl">
+                  <p className="leading-relaxed text-gray-200 text-lg md:text-xl">
                     Hi, I&#39;m{" "}
                     <span
-                      className="font-bold text-primary-600"
+                      className="font-bold text-gray-200"
                       style={{ textShadow: "0 0 5px rgba(97, 157, 253, 0.7)" }}
                     >
                       Raina Moon
@@ -122,7 +150,7 @@ const slideClass = "w-full mx-auto px-5 md:px-10";
                     </span>
                     .
                   </p>
-                  <p className="leading-relaxed text-gray-600 md:text-lg">
+                  <p className="leading-relaxed text-gray-200 md:text-lg">
                     With experience building projects from the ground up, I
                     focus on <span className="font-semibold">clean design</span>
                     , <span className="font-semibold">solid architecture</span>,
@@ -140,7 +168,7 @@ const slideClass = "w-full mx-auto px-5 md:px-10";
               imageClassName="rounded-xl lg:rounded-3xl"
               containerClassName={slideClass}
               textContent={
-                <p className="leading-relaxed text-gray-700 font-medium text-lg md:text-xl flex-1">
+                <p className="leading-relaxed text-gray-200 font-medium text-lg md:text-xl flex-1">
                   I build with <span className="font-bold">Next.js</span>,{" "}
                   <span className="font-bold">TypeScript</span>, and{" "}
                   <span className="font-bold">TailwindCSS</span>, and I&#39;m
@@ -157,7 +185,7 @@ const slideClass = "w-full mx-auto px-5 md:px-10";
               imageClassName="rounded-xl lg:rounded-3xl"
               containerClassName={slideClass}
               textContent={
-                <p className="leading-relaxed text-gray-600 italic text-lg md:text-xl flex-1">
+                <p className="leading-relaxed text-gray-200 italic text-lg md:text-xl flex-1">
                   Recently, I&#39;ve also started learning{" "}
                   <span className="font-bold">React Native</span> to explore{" "}
                   <span className="italic">mobile development</span>.
@@ -174,14 +202,14 @@ const slideClass = "w-full mx-auto px-5 md:px-10";
               containerClassName={slideClass}
               textContent={
                 <div className="flex flex-col gap-2">
-                  <p className="leading-relaxed text-gray-700 text-lg md:text-xl flex-1">
+                  <p className="leading-relaxed text-gray-200 text-lg md:text-xl flex-1">
                     안녕하세요, 저는 빠르게 성장하고 실행력 있게 움직이는{" "}
                     <span className="font-bold text-primary-600">
                       프론트엔드 개발자 Raina
                     </span>
                     입니다.
                   </p>
-                  <p className="leading-relaxed text-gray-600 text-lg md:text-xl flex-1">
+                  <p className="leading-relaxed text-gray-200 text-lg md:text-xl flex-1">
                     다양한 프로젝트를 직접 기획하고 구현하며,{" "}
                     <span className="font-semibold">문제 해결</span>과{" "}
                     <span className="font-semibold">사용자 경험</span>을
@@ -198,7 +226,7 @@ const slideClass = "w-full mx-auto px-5 md:px-10";
               imageClassName="rounded-xl lg:rounded-3xl"
               containerClassName={slideClass}
               textContent={
-                <p className="leading-relaxed text-gray-700 font-medium text-lg md:text-xl flex-1">
+                <p className="leading-relaxed text-gray-200 font-medium text-lg md:text-xl flex-1">
                   현재는 <span className="font-bold">Next.js</span>,{" "}
                   <span className="font-bold">TypeScript</span>,{" "}
                   <span className="font-bold">TailwindCSS</span>를 활용해 웹을
@@ -215,7 +243,7 @@ const slideClass = "w-full mx-auto px-5 md:px-10";
               imageClassName="rounded-xl lg:rounded-3xl"
               containerClassName={slideClass}
               textContent={
-                <p className="leading-relaxed text-gray-600 italic text-lg md:text-xl flex-1">
+                <p className="leading-relaxed text-gray-200 italic text-lg md:text-xl flex-1">
                   최근에는 <span className="font-bold">React Native</span>를
                   공부하며 <span className="font-bold">모바일 개발</span>에도
                   도전하고 있어요.
@@ -238,10 +266,10 @@ const slideClass = "w-full mx-auto px-5 md:px-10";
             isMobileImageHidden
             textContent={
               <div className="flex flex-col gap-2">
-                <p className="leading-relaxed text-gray-700 text-lg md:text-xl">
+                <p className="leading-relaxed text-gray-200 text-lg md:text-xl">
                   Hi, I&#39;m{" "}
                   <span
-                    className="font-bold text-primary-600"
+                    className="font-bold text-gray-200"
                     style={{ textShadow: "0 0 5px rgba(97, 157, 253, 0.7)" }}
                   >
                     Raina Moon
@@ -254,7 +282,7 @@ const slideClass = "w-full mx-auto px-5 md:px-10";
                   </span>
                   .
                 </p>
-                <p className="leading-relaxed text-gray-600 md:text-lg">
+                <p className="leading-relaxed text-gray-200 md:text-lg">
                   With experience building projects from the ground up, I focus
                   on <span className="font-semibold">clean design</span>,{" "}
                   <span className="font-semibold">solid architecture</span>, and{" "}
@@ -270,7 +298,7 @@ const slideClass = "w-full mx-auto px-5 md:px-10";
             isImageLeft
             imageClassName="rounded-xl lg:rounded-3xl"
             textContent={
-              <p className="leading-relaxed text-gray-700 font-medium text-lg md:text-xl flex-1">
+              <p className="leading-relaxed text-gray-200 font-medium text-lg md:text-xl flex-1">
                 I build with <span className="font-bold">Next.js</span>,{" "}
                 <span className="font-bold">TypeScript</span>, and{" "}
                 <span className="font-bold">TailwindCSS</span>, and I&#39;m
@@ -286,7 +314,7 @@ const slideClass = "w-full mx-auto px-5 md:px-10";
             isMobileImageHidden
             imageClassName="rounded-xl lg:rounded-3xl"
             textContent={
-              <p className="leading-relaxed text-gray-600 italic text-lg md:text-xl flex-1">
+              <p className="leading-relaxed text-gray-200 italic text-lg md:text-xl flex-1">
                 Recently, I&#39;ve also started learning{" "}
                 <span className="font-bold">React Native</span> to explore{" "}
                 <span className="italic">mobile development</span>.
@@ -302,14 +330,14 @@ const slideClass = "w-full mx-auto px-5 md:px-10";
             isMobileImageHidden
             textContent={
               <div className="flex flex-col gap-2">
-                <p className="leading-relaxed text-gray-700 text-lg md:text-xl flex-1">
+                <p className="leading-relaxed text-gray-200 text-lg md:text-xl flex-1">
                   안녕하세요, 저는 빠르게 성장하고 실행력 있게 움직이는{" "}
-                  <span className="font-bold text-primary-600">
+                  <span className="font-bold text-gray-200">
                     프론트엔드 개발자 Raina
                   </span>
                   입니다.
                 </p>
-                <p className="leading-relaxed text-gray-600 text-lg md:text-xl flex-1">
+                <p className="leading-relaxed text-gray-200 text-lg md:text-xl flex-1">
                   다양한 프로젝트를 직접 기획하고 구현하며,{" "}
                   <span className="font-semibold">문제 해결</span>과{" "}
                   <span className="font-semibold">사용자 경험</span>을 중심으로
@@ -325,7 +353,7 @@ const slideClass = "w-full mx-auto px-5 md:px-10";
             isImageLeft
             imageClassName="rounded-xl lg:rounded-3xl"
             textContent={
-              <p className="leading-relaxed text-gray-700 font-medium text-lg md:text-xl flex-1">
+              <p className="leading-relaxed text-gray-200 font-medium text-lg md:text-xl flex-1">
                 현재는 <span className="font-bold">Next.js</span>,{" "}
                 <span className="font-bold">TypeScript</span>,{" "}
                 <span className="font-bold">TailwindCSS</span>를 활용해 웹을
@@ -341,7 +369,7 @@ const slideClass = "w-full mx-auto px-5 md:px-10";
             isMobileImageHidden
             imageClassName="rounded-xl lg:rounded-3xl"
             textContent={
-              <p className="leading-relaxed text-gray-600 italic text-lg md:text-xl flex-1">
+              <p className="leading-relaxed text-gray-200 italic text-lg md:text-xl flex-1">
                 최근에는 <span className="font-bold">React Native</span>를
                 공부하며 <span className="font-bold">모바일 개발</span>에도
                 도전하고 있어요.


### PR DESCRIPTION
# Pull Request Template

## Overview
- Purpose of this PR: Add an edge-only “glow ring” effect to the Description cards, and clean up layering so the effect doesn’t break grid alignment.
- Related Issue: None

## Changes
- Description/React
  - Wrapped each card with the glow-card container and inserted a <span className="glow" /> overlay in DescriptionItem.
  - Added pointer handlers to update CSS variables per card (--pointer-°, --pointer-d, --pointer-x, --pointer-y) for interactive glow direction/intensity.
  - Ensured card content always sits above glow layers (.glow-card > * { position: relative; z-index: 1; }).
- Styles (globals.css)
  - Implemented ring mask variables and masking logic:
    - --ring radial mask + conic-gradient ⇒ edge-only color.
  - Introduced tunable CSS variables:
    - --edge (ring thickness), --outset (outer glow spread), --glow-sens (proximity sensitivity).
  - Added shared base for pseudo-elements:
    - ::before, ::after, .glow now absolutely positioned with z-index: 0 and pointer-events: none.
    - Added Safari-friendly masking fallbacks (-webkit-mask-image, -webkit-mask-composite).
  - Removed duplicated/legacy ::before/::after rules and the older inner/center glow so the effect only appears on card edges.

## Testing
- What was tested
  - Verified the glow anchors to the edges only (no center bleed) and follows pointer direction.
  - Checked layout integrity: grid alignment and spacing unchanged after z-index adjustments.
  - Browsers: Chrome, Firefox, Safari (desktop).
  - Responsive: mobile/desktop; hover replaced by proximity (touch will show reduced effect by design).
- Known Issues
  - Older Safari versions may render mask compositing slightly softer.
  - Very low-end devices may see minor repaint cost due to complex masks.
  - Touch devices don’t provide continuous pointer data; effect is subtle without hover.

## Fix
- Fixes #42 